### PR TITLE
Fix permissions only on our installed directory, not all of /opt

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
   when: wildfly_installed.stdout is not defined or not wildfly_installed.stdout
 
 - name: Change wildfly installation permissions
-  file: path={{ wildfly_install_dir }} owner=wildfly group=wildfly mode=0750
+  file: path={{ wildfly_dir }} owner=wildfly group=wildfly mode=0750
         recurse=yes
 
 - name: Create wildfly log directory
@@ -91,5 +91,5 @@
 # If we don't do this, there's a false changed status in the next run for some
 # reason. Try removing this task and running the role twice, it makes no sense.
 - name: Fix permission limbo
-  file: path={{ wildfly_install_dir }} owner=wildfly group=wildfly mode=0750
+  file: path={{ wildfly_dir }} owner=wildfly group=wildfly mode=0750
         recurse=yes


### PR DESCRIPTION
this task:
- name: Change wildfly installation permissions
  file: path={{ wildfly_install_dir }} owner=wildfly group=wildfly mode=0750

is changing the directory permissions on wildfly_install_dir (= /opt),
not just on the directory tree that we created (/opt/wildfly-*).  This
leads to all of /opt being incorrectly permissioned, affecting
anything else that may be installed into /opt.

The fix is to use wildfly_dir instead of wildfly_install_dir in this
task, and in the final task of the play which does likewise.

file: path={{ wildfly_dir }} owner=wildfly group=wildfly mode=0750
          recurse=yes
