### PR TITLE
wildfly_log_dir must be mode 0755 to be used

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,7 @@
         recurse=yes
 
 - name: Create wildfly log directory
-  file: path={{ wildfly_log_dir }} owner=wildfly group=wildfly mode=0644
+  file: path={{ wildfly_log_dir }} owner=wildfly group=wildfly mode=0755
         state=directory
 
 - name: Create wildfly etc directory


### PR DESCRIPTION
wildfly_log_dir is created with mode 0644 (the execute bit is not set)
which prevents wildfly startup from creating the server.log file in
it.  Directories should be mode 0755.  The server.log file created is
mode 0644, so leaving it o=rx is fine.
