### PR TITLE
Remove configuration of UDP ports

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -31,32 +31,16 @@
   firewalld: port={{ wildfly_manage_http_port }}/tcp permanent=true immediate=true
              state=enabled
 
-- name: Open wildfly management http udp port
-  firewalld: port={{ wildfly_manage_http_port }}/udp permanent=true immediate=true
-             state=enabled
-
 - name: Open wildfly management https tcp port
   firewalld: port={{ wildfly_manage_https_port }}/tcp permanent=true immediate=true
-             state=enabled
-
-- name: Open wildfly management https udp port
-  firewalld: port={{ wildfly_manage_https_port }}/udp permanent=true immediate=true
              state=enabled
 
 - name: Open wildfly http tcp port
   firewalld: port={{ wildfly_http_port }}/tcp permanent=true immediate=true
              state=enabled
 
-- name: Open wildfly http udp port
-  firewalld: port={{ wildfly_http_port }}/udp permanent=true immediate=true
-             state=enabled
-
 - name: Open wildfly https tcp port
   firewalld: port={{ wildfly_https_port }}/tcp permanent=true immediate=true
-             state=enabled
-
-- name: Open wildfly https udp port
-  firewalld: port={{ wildfly_https_port }}/udp permanent=true immediate=true
              state=enabled
 
 - name: Enable and start the service


### PR DESCRIPTION
The current role configures UDP ports for HTTP/HTTPS. It is unlikely that these are provisions for QUIC, since Wildfly does not seem to be using QUIC (or at least is not listening for any UDP ports ATM).

This removes the UDP port firewall changes.