### PR TITLE
Fixed another typo

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -40,7 +40,7 @@
     - change standalone data mode
 
 - name: Copy wildfly systemd unit file
-  template: src=wildfly.service.j2 dest={{ wildfly_systemd_dir }}/wildfly owner=root
+  template: src=wildfly.service.j2 dest={{ wildfly_systemd_dir }}/wildfly.service owner=root
             group=root mode=0640
   when: ansible_service_mgr == 'systemd'
   notify:

--- a/templates/wildfly.service.j2
+++ b/templates/wildfly.service.j2
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 User=wildfly
 Group=wildfly
-ExecStart=/opt/wildfly-{{ wildlfy_version }}/bin/standalone.sh
+ExecStart=/opt/wildfly-{{ wildfly_version }}/bin/standalone.sh
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
There are some more issues with the systemd change. Is there a reason, why you are not using the systemd file provided with wildfly under `{{WILDFLY_HOME}}/docs/contrib/scripts/systemd/`? If you are ok with it, I would change the role to include that service, because it would then allow to pull in the details from wildfly.conf as with the init file.