### PR TITLE
Use upstream init.d script

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,7 @@ wildfly_manage_service: true
 wildfly_remove_download_file: true
 
 wildfly_version: 10.0.0.Final
+wildfly_major_v: "{{ wildfly_version.partition('.')[0] }}"
 
 wildfly_user: wildfly
 wildfly_group: wildfly
@@ -22,6 +23,8 @@ wildfly_download_dir: /tmp
 wildfly_install_dir: /opt
 wildfly_dir: "{{ wildfly_install_dir }}/{{ wildfly_name }}"
 wildfly_create_symlink: true
+
+wildfly_init_src_path: "{{ 'docs/contrib/scripts' if wildfly_major_v | version_compare('10', '>=') else 'bin' }}"
 
 wildfly_console_log_dir: "/var/log/wildfly"
 wildfly_console_log_file: "console.log"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ wildfly_download_dir: /tmp
 
 wildfly_install_dir: /opt
 wildfly_dir: "{{ wildfly_install_dir }}/{{ wildfly_name }}"
-wildfly_create_symlink: false
+wildfly_create_symlink: true
 
 wildfly_console_log_dir: "/var/log/wildfly"
 wildfly_console_log_file: "console.log"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -20,6 +20,12 @@
     - restart wildfly
     - change standalone data mode
 
+- name: Create symlink to /etc/default/wildfly.conf
+  file:
+    state: link
+    src: '{{ wildfly_conf_dir }}/wildfly.conf'
+    dest: /etc/default/wildfly.conf
+
 - name: Copy wildfly properties file
   template:
     src: wildfly.properties.j2
@@ -31,9 +37,11 @@
     - restart wildfly
     - change standalone data mode
 
-- name: Copy wildfly init script
-  template: src=wildfly.init.j2 dest={{ wildfly_init_dir }}/wildfly owner=root
-            group=root mode=0750
+- name: Create symlink to upstream init script
+  file:
+    state: link
+    src: '{{ wildfly_install_dir }}/wildfly/bin/init.d/wildfly-init-{{ ansible_os_family | lower }}.sh'
+    dest: '{{ wildfly_init_dir }}/wildfly'
   when: ansible_service_mgr in ['init', 'upstart']
   notify:
     - restart wildfly

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -40,7 +40,7 @@
 - name: Create symlink to upstream init script
   file:
     state: link
-    src: '{{ wildfly_install_dir }}/wildfly/bin/init.d/wildfly-init-{{ ansible_os_family | lower }}.sh'
+    src: '{{ wildfly_install_dir }}/wildfly/{{ wildfly_init_src_path }}/init.d/wildfly-init-{{ ansible_os_family | lower }}.sh'
     dest: '{{ wildfly_init_dir }}/wildfly'
   when: ansible_service_mgr in ['init', 'upstart']
   notify:


### PR DESCRIPTION
Hi!
I'd like to propose two changes^
- create /opt/wildfly symlink by default
- use upstream init.d script as discussed in #22 