### PR TITLE
Flush handlers before starting service

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -85,6 +85,8 @@
       state: enabled
   when: ansible_distribution_version|version_compare(7, '=') and wildfly_manage_firewall
 
+- meta: flush_handlers
+
 - name: Enable and start the service
   service:
     name: wildfly


### PR DESCRIPTION
As of now wildfly service is restarted twice:
1. `Enable and start the service` task
2. changing configs notifies handler and this handler restarts wildfly yet another time at the very last step.
With those changes, handlers are executed before `service task` and thus wildfly gets restarted only once.
