### PR TITLE
Move out wildfly properties template to configure-properties.yml

### DIFF
--- a/tasks/configure-properties.yml
+++ b/tasks/configure-properties.yml
@@ -1,0 +1,10 @@
+- name: Copy wildfly properties file
+  template:
+    src: wildfly.properties.j2
+    dest: '{{ wildfly_conf_dir }}/wildfly.properties'
+    owner: '{{ wildfly_user }}'
+    group: '{{ wildfly_group }}'
+    mode: '0640'
+  notify:
+    - restart wildfly
+    - change standalone data mode

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -26,16 +26,7 @@
     src: '{{ wildfly_conf_dir }}/wildfly.conf'
     dest: /etc/default/wildfly.conf
 
-- name: Copy wildfly properties file
-  template:
-    src: wildfly.properties.j2
-    dest: '{{ wildfly_conf_dir }}/wildfly.properties'
-    owner: '{{ wildfly_user }}'
-    group: '{{ wildfly_group }}'
-    mode: '0640'
-  notify:
-    - restart wildfly
-    - change standalone data mode
+- include: configure-properties.yml
 
 - name: Create symlink to upstream init script
   file:


### PR DESCRIPTION
Hi!
I'm using [packer](https://www.packer.io/) to build AMI with jdk and fully provisioned wildfly.
Unfortunately, wildfly cannot bind on network interfaces (e.g. `eth0`), it needs to know IP address.
During build with packer, `wildfly.properties` get values of the building VM, obviously.
I'd like to be able to bring up new instances from built AMI and for this I need only to change `wildfly.properties` once again and I can't afford to wait for the whole role to execute.
To be able to do that I use something like this:
```yaml
- hosts: all
  vars:
    wildfly_node_name: "{{ ansible_hostname }}"
    wildfly_bind_address: "{{ ansible_eth0.ipv4.address }}"
    wildfly_bind_address_unsecure: "{{ ansible_eth0.ipv4.address }}"
    wildfly_management_bind_address: "{{ ansible_eth0.ipv4.address }}"
  tasks:
    - name: include roles inkatze.wildfly
      include_role:
        name: inkatze.wildfly
        tasks_from: configure-properties
```
This changes `wildfly.properties` with the instance's IP and starts wildfly.
