### PR TITLE
Add wildfly_dir_mode var used to override mode for wildfly_install_dir

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,7 @@ wildfly_download_dir: /tmp
 
 wildfly_install_dir: /opt
 wildfly_dir: "{{ wildfly_install_dir }}/{{ wildfly_name }}"
+wildfly_dir_mode: '0750'
 wildfly_create_symlink: true
 
 wildfly_init_src_path: "{{ 'docs/contrib/scripts' if wildfly_major_v | version_compare('10', '>=') else 'bin' }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -32,7 +32,7 @@
     dest: '{{ wildfly_install_dir }}'
     owner: '{{ wildfly_user }}'
     group: '{{ wildfly_group }}'
-    mode: '0750'
+    mode: '{{ wildfly_dir_mode }}'
     copy: no
     creates: "{{ wildfly_dir }}/bin/standalone.sh"
 


### PR DESCRIPTION
I use `/opt/wildfly/bin/jboss-cli.sh` in consul check.
As of now, `/opt/wildfly` has too restrictive perms that prevent consul user to execute aforementioned script.
