### PR TITLE
Remove unnecessary double quotes from templates/wildfly.conf.j2

### DIFF
--- a/templates/wildfly.conf.j2
+++ b/templates/wildfly.conf.j2
@@ -12,7 +12,7 @@ JBOSS_USER="{{ wildfly_user }}"
 JBOSS_MODE=standalone
 
 ## Configuration for standalone mode
-JBOSS_CONFIG="{{ wildfly_standalone_config_file }}"
+JBOSS_CONFIG={{ wildfly_standalone_config_file }}
 
 {% if wildfly_startup_wait %}
 ## The amount of time to wait for startup


### PR DESCRIPTION
Those double quotes break some of my automation logic.
There no any double quotes for JBOSS_CONFIG in upstream tar.gz
```
$ grep JBOSS_CONFIG /opt/wildfly/bin/init.d/wildfly.conf 
# JBOSS_CONFIG=standalone.xml
```