### PR TITLE
Wait for wildfly to start to make sure valid config was produced

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_install:
 
 install:
 - pip install ansible==2.2.0.0
-- pip install docker-py
-- pip install molecule==1.13.0
+- pip install docker
+- pip install molecule==1.23.0
 
 script:
 - cd ../ && mv wildfly inkatze.wildfly && cd inkatze.wildfly

--- a/molecule.yml
+++ b/molecule.yml
@@ -12,11 +12,56 @@ driver:
   name: docker
 docker:
   containers:
-    - name: wildfly-centos6
+    - name: wildfly-centos6-8.2.1
       image: centos
       image_version: 6.8
 
-    - name: wildfly-centos7
+    - name: wildfly-centos6-9.0.1
+      image: centos
+      image_version: 6.8
+
+    - name: wildfly-centos6-10.1.0
+      image: centos
+      image_version: 6.8
+
+    - name: wildfly-centos7-8.2.1
       image: milcom/centos7-systemd
       image_version: latest
       privileged: True
+
+    - name: wildfly-centos7-9.0.1
+      image: milcom/centos7-systemd
+      image_version: latest
+      privileged: True
+
+    - name: wildfly-centos7-10.1.0
+      image: milcom/centos7-systemd
+      image_version: latest
+      privileged: True
+
+ansible:
+  playbook: playbook.yml
+
+  host_vars:
+    wildfly-centos6-8.2.1:
+      wildfly_version: 8.2.1.Final
+    wildfly-centos6-9.0.1:
+      wildfly_version: 9.0.1.Final
+    wildfly-centos6-10.1.0:
+      wildfly_version: 10.1.0.Final
+    wildfly-centos7-8.2.1:
+      wildfly_version: 8.2.1.Final
+    wildfly-centos7-9.0.1:
+      wildfly_version: 9.0.1.Final
+    wildfly-centos7-10.1.0:
+      wildfly_version: 10.1.0.Final
+
+  group_vars:
+    all:
+      wildfly_remove_download_file: false
+      wildfly_management_users:
+        - { name: 'david', password: 'ruomlig' }
+        - { name: 'roger', password: 'sretaw' }
+      wildfly_app_users:
+        - { name: 'rich', password: 'thgirw' }
+        - { name: 'nick', password: 'nosam' }

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,13 +1,20 @@
 ---
 
-- hosts: wildfly-centos6
+- hosts: all
+  tasks:
+    - name: create a group of all hosts by operating system
+      group_by:
+        key: "{{ ansible_distribution}}-{{ ansible_distribution_major_version }}"
+
+
+- hosts: CentOS-6
   tasks:
     - name: install initscripts
       package:
         name: initscripts
         state: present
 
-- hosts: wildfly-centos7
+- hosts: CentOS-7
   tasks:
     - name: remove requiretty from /etc/sudoers
       lineinfile:
@@ -16,13 +23,6 @@
         state: absent
 
 - hosts: all
-  vars:
-    wildfly_remove_download_file: false
-    wildfly_management_users:
-      - { name: 'david', password: 'ruomlig' }
-      - { name: 'roger', password: 'sretaw' }
-    wildfly_app_users:
-      - { name: 'rich', password: 'thgirw' }
-      - { name: 'nick', password: 'nosam' }
+  any_errors_fatal: true
   roles:
     - role: inkatze.wildfly

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -78,11 +78,16 @@
 
 - meta: flush_handlers
 
-- name: Enable and start the service
-  service:
-    name: wildfly
-    state: started
-    enabled: yes
+- block:
+    - name: Enable and start the service
+      service:
+        name: wildfly
+        state: started
+        enabled: yes
+    - name: Wait for wildfly to start
+      wait_for:
+        path: "{{ wildfly_dir }}/standalone/log/server.log"
+        search_regex: 'started in'
   when: wildfly_manage_service
 
 - name: Delete wildfly tar file


### PR DESCRIPTION
Also success of this wait_for task assures that wildfly is ready to deploy to and no `jboss-cli.sh` commands will fail.
What do you think?
P.S. Don't tag it if it would be merged for I've got some other changes to PR.