### PR TITLE
Unsecure permissions on files extracted from tar.gz

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,7 +24,6 @@ wildfly_download_dir: /tmp
 
 wildfly_install_dir: /opt
 wildfly_dir: "{{ wildfly_install_dir }}/{{ wildfly_name }}"
-wildfly_dir_mode: '0750'
 wildfly_create_symlink: true
 
 wildfly_init_src_path: "{{ 'docs/contrib/scripts' if wildfly_major_v | version_compare('10', '>=') else 'bin' }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -34,7 +34,6 @@
     dest: '{{ wildfly_install_dir }}'
     owner: '{{ wildfly_user }}'
     group: '{{ wildfly_group }}'
-    mode: '{{ wildfly_dir_mode }}'
     copy: no
     creates: "{{ wildfly_dir }}/bin/standalone.sh"
 


### PR DESCRIPTION
As of now when ansible unarchives tar it changes permissions on all extracted files and that raises some security concerns.
we end up with:
```
# ll /opt/wildfly/standalone/configuration/
total 124
-rwxr-xr-x 1 wildfly wildfly   711 Jul 24  2015 application-roles.properties
-rwxr-xr-x 1 wildfly wildfly   935 Jul 24  2015 application-users.properties
-rwxr-xr-x 1 wildfly wildfly  2697 Jul 24  2015 logging.properties
-rwxr-xr-x 1 wildfly wildfly   669 Jul 24  2015 mgmt-groups.properties
-rwxr-xr-x 1 wildfly wildfly  1112 Jul 24  2015 mgmt-users.properties
-rwxr-xr-x 1 wildfly wildfly 29180 Jul 24  2015 standalone-full-ha.xml
-rwxr-xr-x 1 wildfly wildfly 25024 Jul 24  2015 standalone-full.xml
-rwxr-xr-x 1 wildfly wildfly 22607 Jul 24  2015 standalone-ha.xml
-rwxr-xr-x 1 wildfly wildfly 19727 Jul 24  2015 standalone.xml
```
please note
```
-rwxr-xr-x 1 wildfly wildfly   669 Jul 24  2015 mgmt-groups.properties
-rwxr-xr-x 1 wildfly wildfly  1112 Jul 24  2015 mgmt-users.properties
```
in those files there are hashed passwords and they are available for any user to read.

with changes introduced by this PR, permissions are not enforced upon extraction of archive and are as they should be:
```
-rw------- 1 wildfly wildfly   669 Jul 24  2015 mgmt-groups.properties
-rw------- 1 wildfly wildfly  1112 Jul 24  2015 mgmt-users.properties
```
we are not talking about the owner and group may be they are not secure as well but at least those files are not world-readable.
As those changes are not backward-compatible, I'd like to start a discussion on that matter.
