### PR TITLE
Enforce secure permissions

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -24,3 +24,13 @@
     creates: "{{ wildfly_dir }}/.app-users.{{ item.name }}.provisioned"
   when: wildfly_app_users | length > 0
   no_log: True
+
+- name: Enforce secure permissions on password files
+  file:
+    path: "{{ wildfly_dir }}/standalone/configuration/{{ item }}"
+    owner: "{{ wildfly_user }}"
+    group: "{{ wildfly_group }}"
+    mode: "0600"
+  with_items:
+    - mgmt-groups.properties
+    - mgmt-users.properties


### PR DESCRIPTION
enforces secure permissions on
mgmt-groups.properties
mgmt-users.properties
regardless of `wildfly_dir_mode`