### PR TITLE
Use role vars in systemd conf file

### DIFF
--- a/templates/wildfly.service.j2
+++ b/templates/wildfly.service.j2
@@ -4,9 +4,9 @@ After=network.target
 
 [Service]
 Type=simple
-User=wildfly
-Group=wildfly
-EnvironmentFile=/etc/default/wildfly.conf
+User={{ wildfly_user }}
+Group={{ wildfly_group }}
+EnvironmentFile={{ wildfly_conf_dir }}/wildfly.conf
 ExecStart={{ wildfly_dir }}/bin/standalone.sh $JBOSS_OPTS
 
 [Install]


### PR DESCRIPTION
The current systemd unit file has some values we have as vars inside the role hardcoded. These vars included:
- User
- Group
- Wildfly environment file

This resolves #40 and fixes an issue where the environment file was completely ignored in systems using the systemd service manager because the unit file was pointing to a wildfly.conf  file that doesn't exist.