### PR TITLE
Custom conf python3

### DIFF
--- a/templates/wildfly.conf.j2
+++ b/templates/wildfly.conf.j2
@@ -33,6 +33,6 @@ JBOSS_OPTS="-P={{ wildfly_conf_dir }}/wildfly.properties"
 
 
 ## Custom variables
-{% for key, value in (wildfly_custom_environment | default({})).iteritems() %}
+{% for key, value in (wildfly_custom_environment | default({})).items() %}
 {{ key }}={{ value }}
 {% endfor %}

--- a/templates/wildfly.properties.j2
+++ b/templates/wildfly.properties.j2
@@ -15,6 +15,6 @@ jboss.bind.address.unsecure={{ wildfly_bind_address_unsecure }}
 {% if wildfly_messaging_group_address %}
 jboss.messaging.group.address={{ wildfly_messaging_group_address }}
 {% endif %}
-{% for key, value in (wildfly_custom_properties | default({})).iteritems() %}
+{% for key, value in (wildfly_custom_properties | default({})).items() %}
 {{ key }}={{ value }}
 {% endfor %}


### PR DESCRIPTION
Hello,
I really apreciate the new feature of custom properties and configuration, but I encounter an error when using python3: ".iteritems()" does not exists anymore in python3. It has been replaced by ".items()".
The full error:

    TASK [inkatze.wildfly : Copy wildfly properties file] *******************************************************************************
    fatal: [test1-web]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute 'iteritems'"}

So here is how to correct that.
FYI, ".items()" works also in python2. It's just that it is not as efficient as ".iteritems()" with huge dict (See Answer 1. and 2. on this StackOverflow threat: https://stackoverflow.com/questions/30418481/error-dict-object-has-no-attribute-iteritems)