### PR TITLE
Change how we wait for Wildfly to be started

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -86,8 +86,7 @@
         enabled: yes
     - name: Wait for wildfly to start
       wait_for:
-        path: "{{ wildfly_dir }}/standalone/log/server.log"
-        search_regex: 'started in'
+        port: "{{ wildfly_http_port }}"
   when: wildfly_manage_service
 
 - name: Delete wildfly tar file


### PR DESCRIPTION
Hello,
I changed how ansible waits for Wildfly to be started.
The reasons to do so are:
- `started in` does not appears (on my systems) in `{{ wildfly_dir }}/standalone/log/server.log`, but in `{{wildfly_console_log_dir}}/server.log`
- the location of the log in which `started in` must appears does not depend on something configured using this role, but on a wildfly default variable (`org.jboss.boot.log.file`)
- there can be several `started in` in the same file (stop and start again during the same day) which could be misleading. Imagine: Wildfly restarted before during the day, then stopped, and restarted but someting goes wrong, the `started in` is already in the file, and ansible continues with an "OK" state whereas it should not

With this change, we wait for the http port to be open by wildfly meaning wildfly is started and accepting connections on the HTTP port, without relying on logs, but directly on the network layer