### PR TITLE
New variable to create wildfly home directory (=jboss data dir)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ wildfly_major_v: "{{ wildfly_version.partition('.')[0] }}"
 wildfly_manage_user: true
 wildfly_user: wildfly
 wildfly_group: wildfly
+wildfly_home: ''
 
 wildfly_base_download_url: http://download.jboss.org/wildfly
 wildfly_name: wildfly-{{ wildfly_version }}

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -23,7 +23,8 @@
       user:
         name: '{{ wildfly_user }}'
         group: '{{ wildfly_group }}'
-        createhome: no
+        createhome: "{% if wildfly_home == '' %}no{%else%}yes{%endif%}"
+        home: "{% if wildfly_home == '' %}{{omit}}{%else%}{{wildfly_home}}{%endif%}"
         shell: "{{ wildfly_user_shell |default(omit) }}"
         state: present
   when: wildfly_manage_user

--- a/templates/wildfly.properties.j2
+++ b/templates/wildfly.properties.j2
@@ -6,6 +6,9 @@ jboss.http.port={{ wildfly_http_port }}
 jboss.https.port={{ wildfly_https_port }}
 jboss.bind.address.management={{ wildfly_management_bind_address }}
 jboss.server.temp.dir=/tmp/wildfly
+{% if wildfly_home != '' %}
+jboss.server.data.dir={{ wildfly_home }}
+{% endif %}
 {% if wildfly_node_name %}
 jboss.node.name={{ wildfly_node_name }}
 {% endif %}


### PR DESCRIPTION
Hello,
I need to have my data dir outside of wildfly directory, so I need to:
- create the directory referenced by `jboss.server.data.dir` in wildfly conf (before wildfly starts)
- change its ownership to wilfly user and group
I could do that as a pre-task, but before creating that directory, I needed the wildfly user and group to be created.
This PR avoids creating 3 pre-tasks just to use a jboss data dir outside of its default path.