### PR TITLE
Make service able to restart if it was already started earlier

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -86,7 +86,7 @@
     - name: Enable and start the service
       service:
         name: wildfly
-        state: started
+        state: restarted
         enabled: yes
     - name: Wait for wildfly to start
       wait_for:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -86,8 +86,10 @@
     - name: Enable and start the service
       service:
         name: wildfly
-        state: started
+        state: restarted
         enabled: yes
+      changed_when: False
+
     - name: Wait for wildfly to start
       wait_for:
         path: "{{ wildfly_dir }}/standalone/log/server.log"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -88,6 +88,8 @@
         name: wildfly
         state: restarted
         enabled: yes
+      changed_when: False
+
     - name: Wait for wildfly to start
       wait_for:
         path: "{{ wildfly_dir }}/standalone/log/server.log"


### PR DESCRIPTION
If the service was started not today (the log file has allready rolled), then role halts waiting for "started in" in log file, that will never appear as service is started.