### PR TITLE
Fixed ansible distribution check template error

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 
 galaxy_info:
-  author: Juan Diego Romero González
+  author: jadbaz 
   description: Installs Wildfly's application runtime
   license: BSD
   min_ansible_version: 2.2

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -74,7 +74,7 @@
       permanent: yes
       immediate: yes
       state: enabled
-  when: ansible_distribution_version|version_compare(7, '=') and wildfly_manage_firewall
+  when: ansible_distribution_major_version is version('7', '=') and wildfly_manage_firewall 
 
 - meta: flush_handlers
 


### PR DESCRIPTION
This fixes both:
- [#42](https://github.com/inkatze/wildfly/issues/43): using ansible_distribution_major_version instead of ansible_distribution_version
- [#62](https://github.com/inkatze/wildfly/issues/62): using is version instead of version_compare to satisfy Ansible 2.9 breaking change